### PR TITLE
🧹 Update bootstrap helpers to be internal

### DIFF
--- a/test/utils/Bootstrap.sol
+++ b/test/utils/Bootstrap.sol
@@ -13,16 +13,16 @@ import {Test} from "lib/forge-std/src/Test.sol";
 contract Bootstrap is Test {
     using console2 for *;
 
-    Counter public counter;
+    Counter internal counter;
 
-    function initializeOptimismGoerli() public {
+    function initializeOptimismGoerli() internal {
         BootstrapOptimismGoerli bootstrap = new BootstrapOptimismGoerli();
         (address counterAddress) = bootstrap.init();
 
         counter = Counter(counterAddress);
     }
 
-    function initializeOptimism() public {
+    function initializeOptimism() internal {
         BootstrapOptimismGoerli bootstrap = new BootstrapOptimismGoerli();
         (address counterAddress) = bootstrap.init();
 


### PR DESCRIPTION
## Description

Update `counter`, `initializeOptimismGoerli` and `initializeOptimism` from `public` to `internal`.

## Motivation and Context

This is because when running invariant tests, it is often useful to inherit bootstrap and helper contracts that have already been written, to utilise functionality within them. However the invariant test fuzzer will target any public/external functions and fuzz them. This means you need to be careful which functions you expose in these root testing classes, limiting their exposure to only what is necessary.

So for this reason it is helpful to keep variables and functions as `internal` rather than `public` where possible in tests.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?
